### PR TITLE
Update InfoTemplate.cpp

### DIFF
--- a/buildmlearn-toolkit-src/InfoTemplate.cpp
+++ b/buildmlearn-toolkit-src/InfoTemplate.cpp
@@ -143,15 +143,17 @@ void InfoTemplate::on_addButton_cicked()
 
 void InfoTemplate::on_removedButton_cicked()
 {
-    itemList->takeItem(itemList->currentRow());
-    itemList_phone->takeItem(itemList->currentRow());
-    iTitleList.removeAt(itemList->currentRow());
-    iDescriptionList.removeAt(itemList->currentRow());
+    int temp = itemList->currentRow();
+    itemList->takeItem(temp);
+    itemList_phone->takeItem(temp);
+    iTitleList.removeAt(temp);
+    iDescriptionList.removeAt(temp);
 }
 
 void InfoTemplate::on_itemList_selected()
 {
-    textEdit->setPlainText(iDescriptionList.at(itemList->currentRow()));
+    if(itemList->currentItem() != 0)
+      textEdit->setPlainText(iDescriptionList.at(itemList->currentRow()));
 }
 
 void InfoTemplate::on_textEdit_textChanged()


### PR DESCRIPTION
I'm one of the applicants who is interested in applying for GSoC 2014 for your organization and I was going through the codes and the toolkit and discovered a bug.

When making an informative app, I found that when removing the last item from the item list the program crashes.

I have figured out that the slot

``` C++
void InfoTemplate::on_itemList_selected()
{
        textEdit->setPlainText(iDescriptionList.at(itemList->currentRow()));
}
```

gets called after the last item is deleted from the (QListWidget) ItemList which then tries to access a null pointer (deleted item)

I solved it by adding a check for null pointer at the slot.

``` C++
void InfoTemplate::on_itemList_selected()
{
    if(itemList->currentItem() != 0)
        textEdit->setPlainText(iDescriptionList.at(itemList->currentRow()));
}
```

there was also a problem with the remove function which removes the item in the ItemList and proceeds to remove other items from other lists with the index of the "deleted item".

I think by adding a temp integer which possesses the value of the item's index before deleting it fixes the issue.

``` C++
void InfoTemplate::on_removedButton_cicked()
{  
    int temp = itemList->currentRow();
    itemList->takeItem(temp);
    itemList_phone->takeItem(temp);
    iTitleList.removeAt(temp);
    iDescriptionList.removeAt(temp);
}
```

I'm looking forward to working with you in the GSoC 2014!
