### PR TITLE
bug fix

### DIFF
--- a/src/templates/mlearning/basicmlearningeditor.cpp
+++ b/src/templates/mlearning/basicmlearningeditor.cpp
@@ -317,8 +317,11 @@ void BasicmLearningEditor::saveItem() {
   m_activeItem.setTitle(m_ui->m_txtTitle->lineEdit()->text());
   m_activeItem.setDescription(m_ui->m_txtDescription->toPlainText());
 
-  m_ui->m_listItems->currentItem()->setData(Qt::UserRole, QVariant::fromValue(m_activeItem));
-  m_ui->m_listItems->currentItem()->setText(m_activeItem.title());
+  if(m_ui->m_listItems->currentItem() != NULL )
+  {
+    m_ui->m_listItems->currentItem()->setData(Qt::UserRole, QVariant::fromValue(m_activeItem));
+    m_ui->m_listItems->currentItem()->setText(m_activeItem.title());
+  }
 
   emit changed();
 }


### PR DESCRIPTION
bug fix for issue #56 

BasicmLearningEditor::displayItem,  calls m_ui->m_txtDescription->clear() which signals  textChanged().

and then BasicmLearningEditor::saveItem()  calls setData() on  m_ui->m_listItems->currentItem() even there is no item in the list, which results in a crash. 