### PR TITLE
Updating QListWidget in FlashCard template

### DIFF
--- a/src/templates/flashcard/flashcardeditor.cpp
+++ b/src/templates/flashcard/flashcardeditor.cpp
@@ -96,7 +96,7 @@ FlashCardEditor::FlashCardEditor(TemplateCore *core, QWidget *parent)
 
   connect(m_ui->m_btnPictureSelect, SIGNAL(clicked()), this, SLOT(selectPicture()));
   connect(m_ui->m_txtAuthor->lineEdit(), SIGNAL(textChanged(QString)), this, SLOT(onAuthorChanged(QString)));
-  connect(m_ui->m_txtQuestion, SIGNAL(textEdited(QString)), this, SLOT(saveQuestion()));
+  connect(m_ui->m_txtQuestion->lineEdit(), SIGNAL(textEdited(QString)), this, SLOT(saveQuestion()));
   connect(m_ui->m_txtName->lineEdit(), SIGNAL(textChanged(QString)), this, SLOT(onNameChanged(QString)));
   connect(m_ui->m_txtAnswer->lineEdit(), SIGNAL(textEdited(QString)), this, SLOT(onAnswerChanged(QString)));
   connect(m_ui->m_txtHint->lineEdit(), SIGNAL(textEdited(QString)), this, SLOT(onHintChanged(QString)));


### PR DESCRIPTION
Sir, In flashcard template, during editing, question was not updating in Active questions QListWidget when changing the text of question field. This request solves this issue, its a one line solution :).